### PR TITLE
Nullable fixes

### DIFF
--- a/MultiplayerExtensions/Downloader.cs
+++ b/MultiplayerExtensions/Downloader.cs
@@ -49,7 +49,7 @@ namespace MultiplayerExtensions
                 {
                     SongCore.Loader.SongsLoadedEvent += awaiter.OnEvent;
 
-                    SongCore.Collections.AddSong($"custom_level_{hash}", folderPath);
+                    SongCore.Collections.AddSong($"{Utils.CustomLevelIdPrefix}{hash}", folderPath);
                     SongCore.Loader.Instance.RefreshSongs(false);
                     await awaiter.Task;
                 }

--- a/MultiplayerExtensions/HarmonyPatches/CustomSongsPatches.cs
+++ b/MultiplayerExtensions/HarmonyPatches/CustomSongsPatches.cs
@@ -68,7 +68,6 @@ namespace MultiplayerExtensions.HarmonyPatches
     public class LoadLevelPatch
     {
         public static MultiplayerLevelLoader? MultiplayerLevelLoader;
-        public static readonly string CustomLevelPrefix = "custom_level_";
         private static string? LoadingLevelId;
 
         static bool Prefix(ref BeatmapIdentifierNetSerializable beatmapId, ref GameplayModifiers gameplayModifiers, ref float initialStartTime, MultiplayerLevelLoader __instance)

--- a/MultiplayerExtensions/HarmonyPatches/HarmonyManager.cs
+++ b/MultiplayerExtensions/HarmonyPatches/HarmonyManager.cs
@@ -70,7 +70,7 @@ namespace MultiplayerExtensions.HarmonyPatches
                 else if (postfix != null)
                     patchTypeName = postfix.method.DeclaringType?.Name;
                 else if (transpiler != null)
-                    patchTypeName = postfix.method.DeclaringType?.Name;
+                    patchTypeName = transpiler.method.DeclaringType?.Name;
                 Plugin.Log?.Debug($"Harmony patching {original.Name} with {patchTypeName}");
                 harmony.Patch(original, prefix, postfix, transpiler);
                 return true;

--- a/MultiplayerExtensions/HarmonyPatches/InstallerPatches.cs
+++ b/MultiplayerExtensions/HarmonyPatches/InstallerPatches.cs
@@ -15,7 +15,9 @@ namespace MultiplayerExtensions.HarmonyPatches
     class LobbyPlayersDataModelPatch
     {
         private static readonly MethodInfo _rootMethod = typeof(ConcreteBinderNonGeneric).GetMethod(nameof(ConcreteBinderNonGeneric.To), Array.Empty<Type>());
-        private static readonly MethodInfo _overrideAttacher = SymbolExtensions.GetMethodInfo(() => PlayerDataModelAttacher(null));
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+        private static readonly MethodInfo _overrideAttacher = SymbolExtensions.GetMethodInfo(() => PlayerDataModelAttacher(null)); // Harmony magic?
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
         private static readonly MethodInfo _originalMethod = _rootMethod.MakeGenericMethod(new Type[] { typeof(LobbyPlayersDataModel) });
 
         static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/MultiplayerExtensions/HarmonyPatches/InterfacePatches.cs
+++ b/MultiplayerExtensions/HarmonyPatches/InterfacePatches.cs
@@ -66,7 +66,7 @@ namespace MultiplayerExtensions.HarmonyPatches
     public class LevelCollectionViewController_DidSelectLevel
     {
         private static GameObject? beatSaverWarning;
-        private static List<string> songsNotFound = new List<string>();
+        private static HashSet<string> songsNotFound = new HashSet<string>();
 
         /// <summary>
         /// Tells the user when they have selected a song that is not on BeatSaver.com.
@@ -89,9 +89,9 @@ namespace MultiplayerExtensions.HarmonyPatches
 
             beatSaverWarning.SetActive(false);
 
-            if (level.levelID.Contains("custom_level") && LobbyJoinPatch.IsMultiplayer)
+            string? levelHash = Utilities.Utils.LevelIdToHash(level.levelID);
+            if (levelHash != null && LobbyJoinPatch.IsMultiplayer)
             {
-                string levelHash = level.levelID.Replace("custom_level_", "");
                 if (songsNotFound.Contains(levelHash))
                 {
                     Plugin.Log?.Warn($"Could not find song '{levelHash}' on BeatSaver.");

--- a/MultiplayerExtensions/Networking/ExtendedPlayerManager.cs
+++ b/MultiplayerExtensions/Networking/ExtendedPlayerManager.cs
@@ -10,9 +10,9 @@ namespace MultiplayerExtensions.Networking
     public class ExtendedPlayerManager : IInitializable
     {
         [Inject]
-        private ExtendedSessionManager _sessionManager;
+        private ExtendedSessionManager _sessionManager = null!;
 
-        public string localPlatformID;
+        public string? localPlatformID;
 
         public void Initialize()
         {

--- a/MultiplayerExtensions/Networking/ExtendedPlayerPacket.cs
+++ b/MultiplayerExtensions/Networking/ExtendedPlayerPacket.cs
@@ -32,13 +32,13 @@ namespace MultiplayerExtensions.Networking
             ExtendedPlayerPacket.pool.Release(this);
         }
 
-        public ExtendedPlayerPacket Init(string platformID)
+        public ExtendedPlayerPacket Init(string? platformID)
         {
             this.platformID = platformID;
 
             return this;
         }
 
-        public string platformID;
+        public string? platformID;
     }
 }

--- a/MultiplayerExtensions/Networking/ExtendedSessionManager.cs
+++ b/MultiplayerExtensions/Networking/ExtendedSessionManager.cs
@@ -12,14 +12,14 @@ namespace MultiplayerExtensions.Networking
     public class ExtendedSessionManager : IInitializable
     {
         [Inject]
-        private IMultiplayerSessionManager _multiplayerSessionManager;
+        private IMultiplayerSessionManager _multiplayerSessionManager = null!;
 
         private NetworkPacketSerializer<ExtendedSessionManager.MessageType, IConnectedPlayer> _packetSerializer = new NetworkPacketSerializer<ExtendedSessionManager.MessageType, IConnectedPlayer>();
-        public Dictionary<string, ExtendedPlayer> players = new Dictionary<string, ExtendedPlayer>();
+        public readonly Dictionary<string, ExtendedPlayer> players = new Dictionary<string, ExtendedPlayer>();
 
-        public event Action<ExtendedPlayer> playerConnectedEvent;
-        public event Action<ExtendedPlayer> playerDisconnectedEvent;
-        public event Action<ExtendedPlayer> playerStateChangedEvent;
+        public event Action<ExtendedPlayer>? playerConnectedEvent;
+        public event Action<ExtendedPlayer>? playerDisconnectedEvent;
+        public event Action<ExtendedPlayer>? playerStateChangedEvent;
 
         public void Initialize()
         {
@@ -102,9 +102,9 @@ namespace MultiplayerExtensions.Networking
             _packetSerializer.RegisterSubSerializer(serializerType, subSerializer);
         }
 
-        public event Action connectedEvent;
-        public event Action<ConnectionFailedReason> connectionFailedEvent;
-        public event Action<DisconnectedReason> disconnectedEvent;
+        public event Action? connectedEvent;
+        public event Action<ConnectionFailedReason>? connectionFailedEvent;
+        public event Action<DisconnectedReason>? disconnectedEvent;
 
         public IConnectedPlayer localPlayer => _multiplayerSessionManager.localPlayer;
         public bool isConnectionOwner => _multiplayerSessionManager.isConnectionOwner;

--- a/MultiplayerExtensions/OverrideClasses/PlayersDataModelStub.cs
+++ b/MultiplayerExtensions/OverrideClasses/PlayersDataModelStub.cs
@@ -12,6 +12,7 @@ namespace MultiplayerExtensions.OverrideClasses
 {
     class PlayersDataModelStub : LobbyPlayersDataModel, ILobbyPlayersDataModel
     {
+        /*
         // TODO: These fields won't be read if the object is cast as a LobbyPlayersDataModel, can we inject to the base class instead?
         [Inject]
         protected readonly BeatmapLevelsModel _beatmapLevelsModel = null!;
@@ -21,7 +22,7 @@ namespace MultiplayerExtensions.OverrideClasses
 
         [Inject]
         protected readonly IMenuRpcManager _menuRpcManager = null!;
-
+        */
         [Inject]
         protected readonly ExtendedSessionManager _sessionManager = null!;
 

--- a/MultiplayerExtensions/OverrideClasses/PlayersDataModelStub.cs
+++ b/MultiplayerExtensions/OverrideClasses/PlayersDataModelStub.cs
@@ -13,16 +13,16 @@ namespace MultiplayerExtensions.OverrideClasses
     class PlayersDataModelStub : LobbyPlayersDataModel, ILobbyPlayersDataModel
     {
         [Inject]
-        protected readonly BeatmapLevelsModel _beatmapLevelsModel;
+        protected readonly BeatmapLevelsModel _beatmapLevelsModel = null!;
 
         [Inject]
-        protected readonly BeatmapCharacteristicCollectionSO _beatmapCharacteristicCollection;
+        protected readonly BeatmapCharacteristicCollectionSO _beatmapCharacteristicCollection = null!;
 
         [Inject]
-        protected readonly IMenuRpcManager _menuRpcManager;
+        protected readonly IMenuRpcManager _menuRpcManager = null!;
 
         [Inject]
-        protected readonly ExtendedSessionManager _sessionManager;
+        protected readonly ExtendedSessionManager _sessionManager = null!;
 
         public PlayersDataModelStub() { }
 

--- a/MultiplayerExtensions/OverrideClasses/PlayersDataModelStub.cs
+++ b/MultiplayerExtensions/OverrideClasses/PlayersDataModelStub.cs
@@ -12,6 +12,7 @@ namespace MultiplayerExtensions.OverrideClasses
 {
     class PlayersDataModelStub : LobbyPlayersDataModel, ILobbyPlayersDataModel
     {
+        // TODO: These fields won't be read if the object is cast as a LobbyPlayersDataModel, can we inject to the base class instead?
         [Inject]
         protected readonly BeatmapLevelsModel _beatmapLevelsModel = null!;
 

--- a/MultiplayerExtensions/PreviewBeatmaps/PreviewBeatmapManager.cs
+++ b/MultiplayerExtensions/PreviewBeatmaps/PreviewBeatmapManager.cs
@@ -25,7 +25,7 @@ namespace MultiplayerExtensions.Beatmaps
         public static PreviewBeatmapStub GetPreview(PreviewBeatmapPacket packet)
             => GetPreview(packet.levelId, packet.songName, packet.songSubName, packet.songAuthorName, packet.levelAuthorName);
 
-        public static PreviewBeatmapStub GetPreview(string levelId, string songName, string songSubName, string songAuthorName, string levelAuthorName)
+        public static PreviewBeatmapStub GetPreview(string levelId, string? songName, string? songSubName, string? songAuthorName, string? levelAuthorName)
         {
             if (CachedPreviews.ContainsKey(levelId))
             {
@@ -51,7 +51,7 @@ namespace MultiplayerExtensions.Beatmaps
             return beatmap;
         }
 
-        public static PreviewBeatmapStub FetchPreview(string levelId, string songName, string songSubName, string songAuthorName, string levelAuthorName)
+        public static PreviewBeatmapStub FetchPreview(string levelId, string? songName, string? songSubName, string? songAuthorName, string? levelAuthorName)
         {
             PreviewBeatmapStub beatmap = new PreviewBeatmapStub(levelId, songName, songSubName, songAuthorName, levelAuthorName);
             _ = beatmap.FetchPopulated();

--- a/MultiplayerExtensions/PreviewBeatmaps/PreviewBeatmapPacket.cs
+++ b/MultiplayerExtensions/PreviewBeatmaps/PreviewBeatmapPacket.cs
@@ -45,9 +45,21 @@ namespace MultiplayerExtensions.Beatmaps
             PreviewBeatmapPacket.pool.Release(this);
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="levelId"></param>
+        /// <param name="songName"></param>
+        /// <param name="songSubName"></param>
+        /// <param name="songAuthorName"></param>
+        /// <param name="levelAuthorName"></param>
+        /// <param name="characteristic"></param>
+        /// <param name="difficulty"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
         public PreviewBeatmapPacket Init(string levelId, string songName, string songSubName, string songAuthorName, string levelAuthorName, string characteristic, BeatmapDifficulty difficulty)
         {
-            this.levelId = levelId;
+            this.levelId = levelId ?? throw new ArgumentNullException(nameof(levelId));
             this.songName = songName;
             this.songSubName = songSubName;
             this.songAuthorName = songAuthorName;
@@ -58,9 +70,17 @@ namespace MultiplayerExtensions.Beatmaps
             return this;
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="preview"></param>
+        /// <param name="characteristic"></param>
+        /// <param name="difficulty"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentException"></exception>
         public PreviewBeatmapPacket FromPreview(PreviewBeatmapStub preview, string characteristic, BeatmapDifficulty difficulty)
         {
-            this.levelId = preview.levelID;
+            this.levelId = preview.levelID ?? throw new ArgumentException("PreviewBeatmapStub has a null levelID", nameof(preview));
             this.songName = preview.songName;
             this.songSubName = preview.songSubName;
             this.songAuthorName = preview.songAuthorName;
@@ -71,12 +91,12 @@ namespace MultiplayerExtensions.Beatmaps
             return this;
         }
 
-        public string levelId;
-        public string songName;
-        public string songSubName;
-        public string songAuthorName;
-        public string levelAuthorName;
-        public string characteristic;
+        public string levelId = null!;
+        public string? songName;
+        public string? songSubName;
+        public string? songAuthorName;
+        public string? levelAuthorName;
+        public string? characteristic;
         public BeatmapDifficulty difficulty;
     }
 }

--- a/MultiplayerExtensions/PreviewBeatmaps/PreviewBeatmapStub.cs
+++ b/MultiplayerExtensions/PreviewBeatmaps/PreviewBeatmapStub.cs
@@ -68,6 +68,11 @@ namespace MultiplayerExtensions.Beatmaps
         private readonly object _fetchLock = new object();
         public Task<Beatmap?> FetchBeatmap()
         {
+            if(!levelID.ToLower().StartsWith(Utilities.Utils.CustomLevelIdPrefix))
+            {
+                Plugin.Log?.Debug($"Level '{levelID}' seems to be a base game level.");
+                return Task.FromResult<Beatmap?>(null);
+            }
             if (levelHash == null || levelHash.Length == 0)
             {
                 Plugin.Log?.Warn($"Beatmap with level ID '{levelID}' cannot be converted to a valid Beat Saver hash.");

--- a/MultiplayerExtensions/PreviewBeatmaps/PreviewBeatmapStub.cs
+++ b/MultiplayerExtensions/PreviewBeatmaps/PreviewBeatmapStub.cs
@@ -11,7 +11,7 @@ namespace MultiplayerExtensions.Beatmaps
 {
     class PreviewBeatmapStub : IPreviewBeatmapLevel
     {
-        public string levelHash { get; private set; }
+        public string? levelHash { get; private set; }
         public bool isDownloaded { get; private set; }
         public bool isDownloadable { get; private set; }
         public string? downloadURL { get; private set; }
@@ -30,14 +30,27 @@ namespace MultiplayerExtensions.Beatmaps
             }
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="levelID"></param>
+        /// <exception cref="ArgumentNullException"></exception>
         public PreviewBeatmapStub(string levelID)
         {
-            this.levelID = levelID;
-            this.levelHash = Utilities.Utils.LevelIdToHash(levelID)!;
+            this.levelID = levelID ?? throw new ArgumentNullException(nameof(levelID));
+            this.levelHash = Utilities.Utils.LevelIdToHash(levelID);
             _localPreview = SongCore.Loader.GetLevelById(levelID);
             Populate(_localPreview);
         }
-
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="levelID"></param>
+        /// <param name="songName"></param>
+        /// <param name="songSubName"></param>
+        /// <param name="songAuthorName"></param>
+        /// <param name="levelAuthorName"></param>
+        /// <exception cref="ArgumentNullException"></exception>
         public PreviewBeatmapStub(string levelID, string? songName, string? songSubName, string? songAuthorName, string? levelAuthorName) : this(levelID)
         {
             this.songName = songName;

--- a/MultiplayerExtensions/PreviewBeatmaps/PreviewBeatmapStub.cs
+++ b/MultiplayerExtensions/PreviewBeatmaps/PreviewBeatmapStub.cs
@@ -38,7 +38,7 @@ namespace MultiplayerExtensions.Beatmaps
             Populate(_localPreview);
         }
 
-        public PreviewBeatmapStub(string levelID, string songName, string songSubName, string songAuthorName, string levelAuthorName) : this(levelID)
+        public PreviewBeatmapStub(string levelID, string? songName, string? songSubName, string? songAuthorName, string? levelAuthorName) : this(levelID)
         {
             this.songName = songName;
             this.songSubName = songSubName;
@@ -52,7 +52,7 @@ namespace MultiplayerExtensions.Beatmaps
             return this;
         }
 
-        private object _fetchLock = new object();
+        private readonly object _fetchLock = new object();
         public Task<Beatmap?> FetchBeatmap()
         {
             if (levelHash == null || levelHash.Length == 0)

--- a/MultiplayerExtensions/Utilities/Utils.cs
+++ b/MultiplayerExtensions/Utilities/Utils.cs
@@ -12,6 +12,10 @@ namespace MultiplayerExtensions.Utilities
     public static class Utils
     {
         /// <summary>
+        /// 'custom_level_'
+        /// </summary>
+        public static readonly string CustomLevelIdPrefix = "custom_Level_";
+        /// <summary>
         /// Logger for debugging sprite loads.
         /// </summary>
         public static Action<string?, Exception?>? Logger;

--- a/MultiplayerExtensions/Utilities/Utils.cs
+++ b/MultiplayerExtensions/Utilities/Utils.cs
@@ -14,7 +14,7 @@ namespace MultiplayerExtensions.Utilities
         /// <summary>
         /// 'custom_level_'
         /// </summary>
-        public static readonly string CustomLevelIdPrefix = "custom_Level_";
+        public static readonly string CustomLevelIdPrefix = "custom_level_";
         /// <summary>
         /// Logger for debugging sprite loads.
         /// </summary>


### PR DESCRIPTION
* Corrected most nullable warnings (needs review to make sure they make sense)
* Fixed a bug in `HarmonyManager`
  * Was checking if `transpiler` was null, but then using `postfix`
* Added TODO to `PlayersDataModelStub`
  * Possible to use the base class's fields? Ours won't be used if `PlayersDataModelStub` is cast as a `LobbyPlayersDataModel`
* ~~`LobbyPlayersDataModelPatch._overrideAttacher` also needs attention. unless there's something weird I don't know about, it's an automatic NullReferenceException (and was probably hidden by the HarmonyManager bug?)~~
* Small tweaks to the downloader