### PR TITLE
Changed 'pc' to 'Oculus (Desktop)' because that's more clear in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,4 +89,4 @@ You can support development of MultiplayerExtensions by donating at the followin
 ## Related Mods
 * [BeatSaberServerBrowser](https://github.com/roydejong/BeatSaberServerBrowser)
 * [MultiplayerAvatars](https://github.com/Goobwabber/MultiplayerAvatars)
-* BeatTogether for [PC](https://github.com/pythonology/BeatTogether) or [Quest](https://github.com/pythonology/BeatTogether.Quest)
+* BeatTogether for [Oculus (Desktop)](https://github.com/pythonology/BeatTogether) or [Quest](https://github.com/pythonology/BeatTogether.Quest)


### PR DESCRIPTION
It wasn't clear to me (and some other people) that the desktop oculus client doesn't work without the BeatTogether mod also installed.
So hopefully this change in terminology will make it more clear to people