### PR TITLE
Fix null check for beatmap hash in LoadLevel

### DIFF
--- a/MultiplayerExtensions/OverrideClasses/LevelLoaderStub.cs
+++ b/MultiplayerExtensions/OverrideClasses/LevelLoaderStub.cs
@@ -10,7 +10,7 @@ namespace MultiplayerExtensions.OverrideClasses
         {
             string? levelId = beatmapId.levelID;
             string? hash = Utilities.Utils.LevelIdToHash(beatmapId.levelID);
-            if (SongCore.Collections.songWithHashPresent(hash) || hash == null)
+            if (hash == null || SongCore.Collections.songWithHashPresent(hash))
             {
                 Plugin.Log?.Debug($"(SongLoader) Level with ID '{levelId}' already exists.");
                 base.LoadLevel(beatmapId, gameplayModifiers, initialStartTime);


### PR DESCRIPTION
The null check on hash should be before the call to SongCore.Collections.songWithHashPresent, because it will throw a NullReferenceException if passed null (happens when a built in level is selected).

```
[WARNING @ 21:37:14 | MultiplayerExtensions] An exception was thrown processing a packet from player '***' (1): Object reference not set to an instance of an object
[DEBUG @ 21:37:14 | MultiplayerExtensions] System.NullReferenceException: Object reference not set to an instance of an object
[DEBUG @ 21:37:14 | MultiplayerExtensions]   at SongCore.Collections.songWithHashPresent (System.String hash) [0x00000] in <a877910969b047f69c8012bca743f52b>:0 
[DEBUG @ 21:37:14 | MultiplayerExtensions]   at MultiplayerExtensions.OverrideClasses.LevelLoaderStub.LoadLevel (BeatmapIdentifierNetSerializable beatmapId, GameplayModifiers gameplayModifiers, System.Single initialStartTime) [0x0003f] in <34345117ce0e4f90bf0fc4adbcbf2834>:0 
[DEBUG @ 21:37:14 | MultiplayerExtensions]   at LobbyGameStateController.HandleMenuRpcManagerStartedLevel (System.String userId, BeatmapIdentifierNetSerializable beatmapId, GameplayModifiers gameplayModifiers, System.Single startTime) [0x00082] in <0c396efd180746249653ab114cef2375>:0 
[DEBUG @ 21:37:14 | MultiplayerExtensions]   at MultiplayerExtensions.OverrideClasses.GameStateControllerStub.HandleRpcStartedLevel (System.String userId, BeatmapIdentifierNetSerializable beatmapId, GameplayModifiers gameplayModifiers, System.Single startTime) [0x00018] in <34345117ce0e4f90bf0fc4adbcbf2834>:0 
[DEBUG @ 21:37:14 | MultiplayerExtensions]   at MenuRpcManager.InvokeStartLevel (System.String userId, BeatmapIdentifierNetSerializable beatmapId, GameplayModifiers gameplayModifiers, System.Single startTime) [0x0000a] in <92d56d2741224e36be2aa64b1579d870>:0 
[DEBUG @ 21:37:14 | MultiplayerExtensions]   at RpcHandler`1+<>c__DisplayClass16_0`4[TType,T,T0,T1,T2].<RegisterCallback>b__0 (IConnectedPlayer player, T rpc) [0x00032] in <92d56d2741224e36be2aa64b1579d870>:0 
[DEBUG @ 21:37:14 | MultiplayerExtensions]   at RpcHandler`1+<>c__DisplayClass23_0`1[TType,T].<RegisterCallback>b__0 (T rpc, IConnectedPlayer player) [0x00093] in <92d56d2741224e36be2aa64b1579d870>:0 
[DEBUG @ 21:37:14 | MultiplayerExtensions]   at NetworkPacketSerializer`2+<>c__DisplayClass7_0`1[TType,TData,TPacket].<RegisterCallback>b__1 (LiteNetLib.Utils.NetDataReader reader, System.Int32 size, TData data) [0x00013] in <92d56d2741224e36be2aa64b1579d870>:0 
[DEBUG @ 21:37:14 | MultiplayerExtensions]   at NetworkPacketSerializer`2[TType,TData].ProcessPacketInternal (LiteNetLib.Utils.NetDataReader reader, System.Int32 length, TData data) [0x0001f] in <92d56d2741224e36be2aa64b1579d870>:0 
[DEBUG @ 21:37:14 | MultiplayerExtensions]   at NetworkPacketSerializer`2[TType,TData].INetworkPacketSubSerializer<TData>.Deserialize (LiteNetLib.Utils.NetDataReader reader, System.Int32 length, TData data) [0x00000] in <92d56d2741224e36be2aa64b1579d870>:0 
[DEBUG @ 21:37:14 | MultiplayerExtensions]   at NetworkPacketSerializer`2+<>c__DisplayClass9_0[TType,TData].<RegisterSubSerializer>b__0 (LiteNetLib.Utils.NetDataReader reader, System.Int32 size, TData data) [0x00000] in <92d56d2741224e36be2aa64b1579d870>:0 
[DEBUG @ 21:37:14 | MultiplayerExtensions]   at NetworkPacketSerializer`2[TType,TData].ProcessPacketInternal (LiteNetLib.Utils.NetDataReader reader, System.Int32 length, TData data) [0x0001f] in <92d56d2741224e36be2aa64b1579d870>:0 
[DEBUG @ 21:37:14 | MultiplayerExtensions]   at NetworkPacketSerializer`2[TType,TData].INetworkPacketSubSerializer<TData>.Deserialize (LiteNetLib.Utils.NetDataReader reader, System.Int32 length, TData data) [0x00000] in <92d56d2741224e36be2aa64b1579d870>:0 
[DEBUG @ 21:37:14 | MultiplayerExtensions]   at NetworkPacketSerializer`2+<>c__DisplayClass9_0[TType,TData].<RegisterSubSerializer>b__0 (LiteNetLib.Utils.NetDataReader reader, System.Int32 size, TData data) [0x00000] in <92d56d2741224e36be2aa64b1579d870>:0 
[DEBUG @ 21:37:14 | MultiplayerExtensions]   at NetworkPacketSerializer`2[TType,TData].ProcessPacketInternal (LiteNetLib.Utils.NetDataReader reader, System.Int32 length, TData data) [0x0001f] in <92d56d2741224e36be2aa64b1579d870>:0 
[DEBUG @ 21:37:14 | MultiplayerExtensions]   at NetworkPacketSerializer`2[TType,TData].ProcessPacket (LiteNetLib.Utils.NetDataReader reader, TData data) [0x00011] in <92d56d2741224e36be2aa64b1579d870>:0 
[DEBUG @ 21:37:14 | MultiplayerExtensions]   at NetworkPacketSerializer`2[TType,TData].ProcessAllPackets (LiteNetLib.Utils.NetDataReader reader, TData data) [0x00000] in <92d56d2741224e36be2aa64b1579d870>:0 
[DEBUG @ 21:37:14 | MultiplayerExtensions]   at (wrapper dynamic-method) ConnectedPlayerManager.ConnectedPlayerManager.OnNetworkReceive_Patch0(ConnectedPlayerManager,IConnection,LiteNetLib.Utils.NetDataReader,LiteNetLib.DeliveryMethod)
```