### PR TITLE
Fix the layout of the center lights when an even number of players is playing

### DIFF
--- a/MultiplayerExtensions/HarmonyPatches/HarmonyManager.cs
+++ b/MultiplayerExtensions/HarmonyPatches/HarmonyManager.cs
@@ -38,6 +38,7 @@ namespace MultiplayerExtensions.HarmonyPatches
             AddDefaultPatch<UpdateReliableFrequencyPatch>();
             AddDefaultPatch<UpdateUnreliableFrequencyPatch>();
             AddDefaultPatch<PlayerPlacementAnglePatch>();
+            AddDefaultPatch<PlayerLayoutSpotsCountPatch>();
             AddDefaultPatch<IncreaseMaxPlayersClampPatch>();
             AddDefaultPatch<IncreaseMaxPlayersPatch>();
             AddDefaultPatch<MissingLevelStartPatch>();

--- a/MultiplayerExtensions/HarmonyPatches/MaxPlayerPatches.cs
+++ b/MultiplayerExtensions/HarmonyPatches/MaxPlayerPatches.cs
@@ -29,6 +29,34 @@ namespace MultiplayerExtensions.HarmonyPatches
             return codes.AsEnumerable();
         }
     }
+    
+    [HarmonyPatch(typeof(MultiplayerLayoutProvider), "CalculateLayout", MethodType.Normal)]
+    internal class PlayerLayoutSpotsCountPatch
+    {
+        internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            var codes = instructions.ToList();
+            bool flag = false;
+            for (int i = 0; i < codes.Count; i++)
+            {
+                if (codes[i].opcode == OpCodes.Ldc_I4_1)
+                {
+                    flag = true;
+                    continue;
+                }
+
+                if (codes[i].opcode == OpCodes.Add && flag)
+                {
+                    codes.RemoveAt(i);
+                    codes.RemoveAt(i - 1);
+                    break;
+                }
+
+                flag = false;
+            }
+            return codes.AsEnumerable();
+        }
+    }
 
     [HarmonyPatch(typeof(CreateServerFormController), "formData", MethodType.Getter)]
     internal class IncreaseMaxPlayersClampPatch


### PR DESCRIPTION
This patch makes `MultiplayerLayoutProvider` use the real player count instead of using the next uneven number, so the layout of the center lights matches the placement of the players tracks.

Before:
![before](https://user-images.githubusercontent.com/8437403/109070200-7d394300-76f2-11eb-8c0d-4d1f7886f0eb.jpg)

After:
![after](https://user-images.githubusercontent.com/8437403/109070229-875b4180-76f2-11eb-889a-44c5044f7556.jpg)
