### PR TITLE
handleLevelFinished: nullref check levelCompletionResults

### DIFF
--- a/MultiplayerExtensions/OverrideClasses/GameStateControllerStub.cs
+++ b/MultiplayerExtensions/OverrideClasses/GameStateControllerStub.cs
@@ -183,7 +183,11 @@ namespace MultiplayerExtensions.OverrideClasses
 
         private void handleLevelFinished(MultiplayerLevelScenesTransitionSetupDataSO sceneSetupData, MultiplayerResultsData resultsData)
         {
+            if (resultsData.localPlayerResultData.levelCompletionResults == null)
+                return;
+            
             string? hash = Utilities.Utils.LevelIdToHash(sceneSetupData.previewBeatmapLevel.levelID);
+            
             if (hash != null)
                 _ = Statistics.PlayMap(hash, sceneSetupData.beatmapDifficulty.ToString(), sceneSetupData.beatmapCharacteristic.serializedName, (int)Math.Floor(resultsData.localPlayerResultData.levelCompletionResults.endSongTime), (int)ExtendedPlayerManager.localPlatform, MPState.CurrentMasterServer.hostname);
         }


### PR DESCRIPTION
This addresses a potential lobby-breaking bug, possibly semi-related to issues #120 and #119.

If multiplayer gameplay ends early but without actually finishing the level, e.g. when the host selects "End Game" (whenever `ReturnToMenuRpc` is sent), the lobby environment will fail to load due to a null reference on the `resultsData.localPlayerResultData.levelCompletionResults` field.