### PR TITLE
Fixes for Platform Colors (#128)

### DIFF
--- a/MultiplayerExtensions/Environments/LobbyAvatarPlaceLighting.cs
+++ b/MultiplayerExtensions/Environments/LobbyAvatarPlaceLighting.cs
@@ -27,10 +27,14 @@ namespace MultiplayerExtensions.Environments
         protected virtual void Update()
         {
             Color current = GetColor();
-            if (!IsColorVeryCloseToColor(current, targetColor))
-            {
+
+            if (current == targetColor)
+                return;
+            
+            if (IsColorVeryCloseToColor(current, targetColor))
+                SetColor(targetColor);
+            else
                 SetColor(Color.Lerp(current, targetColor, Time.deltaTime * smoothTime));
-            }
         }
 
         public virtual void SetColor(Color color, bool immediate)

--- a/MultiplayerExtensions/Environments/LobbyEnvironmentManager.cs
+++ b/MultiplayerExtensions/Environments/LobbyEnvironmentManager.cs
@@ -48,7 +48,19 @@ namespace MultiplayerExtensions.Environments
 
 		private void HandleLobbyEnvironmentLoaded(object sender, System.EventArgs e)
 		{
-			avatarPlaces = (from place in Resources.FindObjectsOfTypeAll<MultiplayerLobbyAvatarPlace>() select place.gameObject.AddComponent<LobbyAvatarPlaceLighting>()).ToArray();
+			var nativeAvatarPlaces = Resources.FindObjectsOfTypeAll<MultiplayerLobbyAvatarPlace>();
+			avatarPlaces = new LobbyAvatarPlaceLighting[nativeAvatarPlaces.Length];
+			for (var i = 0; i < nativeAvatarPlaces.Length; i++)
+			{
+				var nativeAvatarPlace = nativeAvatarPlaces[i];
+				
+				var avatarPlace = nativeAvatarPlace.GetComponent<LobbyAvatarPlaceLighting>();
+				if (avatarPlace == null)
+					avatarPlace = nativeAvatarPlace.gameObject.AddComponent<LobbyAvatarPlaceLighting>();
+				
+				avatarPlaces[i] = avatarPlace;
+			}
+			
 			innerCircleRadius = _placeManager.GetField<float, MultiplayerLobbyAvatarPlaceManager>("_innerCircleRadius");
 			minOuterCircleRadius = _placeManager.GetField<float, MultiplayerLobbyAvatarPlaceManager>("_minOuterCircleRadius");
 			angleBetweenPlayersWithEvenAdjustment = MultiplayerPlayerPlacement.GetAngleBetweenPlayersWithEvenAdjustment(_lobbyStateDataModel.maxPartySize, MultiplayerPlayerLayout.Circle);
@@ -61,7 +73,7 @@ namespace MultiplayerExtensions.Environments
 			float centerScreenScale = outerCircleRadius / minOuterCircleRadius;
 			_stageManager.transform.localScale = new Vector3(centerScreenScale, centerScreenScale, centerScreenScale);
 
-			SetAllPlayerPlaceColors(Color.black);
+			SetAllPlayerPlaceColors(Color.black, true);
 			SetPlayerPlaceColor(_sessionManager.localPlayer, ExtendedPlayerManager.localColor);
 			foreach (ExtendedPlayer player in _playerManager.players.Values)
 				SetPlayerPlaceColor(player, player.playerColor);
@@ -73,11 +85,11 @@ namespace MultiplayerExtensions.Environments
 		private void HandlePlayerDisconnected(IConnectedPlayer player)
 			=> SetPlayerPlaceColor(player, Color.black);
 
-		public void SetAllPlayerPlaceColors(Color color)
+		public void SetAllPlayerPlaceColors(Color color, bool immediate = false)
         {
 			foreach (LobbyAvatarPlaceLighting place in avatarPlaces)
             {
-				place.SetColor(color, false);
+				place.SetColor(color, immediate);
             }
 		}
 


### PR DESCRIPTION
This PR addresses #128.

- Fix: Prevents the `LobbyAvatarPlaceLighting` component getting attached multiple times (root cause of problems)
- Minor tweak: Snaps the color to its final value when the lerp is near completion

This fixes lights getting dimmer between joins and/or not reaching full brightness. May also help with performance as it prevents the lights being set/refreshed excessively.

Love the way the lobby looks with diverse lights :)

![image](https://user-images.githubusercontent.com/6772638/121580921-93fb6f80-ca2d-11eb-8fb0-52a7cc9416c6.png)
